### PR TITLE
[BUGFIX] Make class name visitors ignore ::class tokens

### DIFF
--- a/src/Gnugat/NomoSpaco/Token/ClassnameVisitor.php
+++ b/src/Gnugat/NomoSpaco/Token/ClassnameVisitor.php
@@ -34,6 +34,6 @@ class ClassnameVisitor implements Visitor
      */
     public function supports(array $tokens, $index)
     {
-        return (isset($tokens[$index][0]) && T_CLASS === $tokens[$index][0]);
+        return (isset($tokens[$index][0]) && T_CLASS === $tokens[$index][0] && T_DOUBLE_COLON !== $tokens[$index - 1][0]);
     }
 }

--- a/src/Gnugat/NomoSpaco/Token/ForClassnameVisitor.php
+++ b/src/Gnugat/NomoSpaco/Token/ForClassnameVisitor.php
@@ -43,6 +43,6 @@ class ForClassnameVisitor implements Visitor
      */
     public function supports(array $tokens, $index)
     {
-        return (isset($tokens[$index][0]) && T_CLASS === $tokens[$index][0]);
+        return (isset($tokens[$index][0]) && T_CLASS === $tokens[$index][0] && T_DOUBLE_COLON !== $tokens[$index - 1][0]);
     }
 }


### PR DESCRIPTION
Hi,

Currently, the class name visitors support the `T_CLASS` token type, but this token type can refer to a regular class declaration AND to a `class` magic constant (`::class`). So, if there are calls to `::class` in the class body, an error will likely be thrown because the next tokens will surely not be a whitespace and a string/class name.

This PR fixes this by making sure we’re dealing with a class declaration keyword and not a class magic constant.