### PR TITLE
Fix #7 - add composer binary

### DIFF
--- a/bin/nomo-spaco
+++ b/bin/nomo-spaco
@@ -1,0 +1,13 @@
+#!/usr/bin/env php
+<?php
+
+$autoloadPath = '/../vendor/autoload.php';
+require_once file_exists(__DIR__.$autoloadPath) ? __DIR__.$autoloadPath : __DIR__.'/../../..'.$autoloadPath;
+
+$script = $argv[0];
+if (2 !== $argc) {
+    die("Usage: 'php $script <projectRoot>'\n");
+}
+$projectRoot = $argv[1];
+$fqcnRepository = \test\Gnugat\NomoSpaco\make_fqcn_repository();
+echo implode(PHP_EOL, $fqcnRepository->findIn($projectRoot));

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,9 @@
         },
         "files": ["test/make_fqcn_repository.php"]
     },
+    "bin": [
+        "bin/nomo-spaco"
+    ],
     "authors": [
         {
             "name": "Loïc Chardonnet",


### PR DESCRIPTION
You should also create the gnugat/nomo-spaco on packagist.org. Currently, installation instructions via composer don't work.